### PR TITLE
Set usermetadata on signin

### DIFF
--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -28,7 +28,7 @@ const SignIn = () => {
     formState: { errors },
   } = useForm<FormInput>();
 
-  const onSubmit: SubmitHandler<FormInput> = async (data: FormInput) => {
+  const onSubmit: SubmitHandler<FormInput> = (data: FormInput) => {
     signIn(data.email, data.password);
   };
 

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -19,7 +19,7 @@ type FormInput = {
 
 const SignUp = () => {
   // Redirect to home page if user already exists
-  const { user, authError, signUp } = useAuth();
+  const { user, authError, signUp, setUserMetadata } = useAuth();
   const router = useRouter();
 
   const {
@@ -28,11 +28,14 @@ const SignUp = () => {
     formState: { errors },
   } = useForm<FormInput>();
 
-  const onSubmit: SubmitHandler<FormInput> = async (data: FormInput) => {
+  const onSubmit: SubmitHandler<FormInput> = (data: FormInput) => {
     signUp(data.email, data.password);
   };
 
   if (user) {
+    // HACK: Temporary fix to set the dataset until the Codebox component is complete
+    setUserMetadata({ dataset: "8b5a92ba-aaae-4223-83d2-4eab40e7a22e" });
+
     router.push("/");
     return null;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export type Dataset = {
   instructions: string;
   name: string;
   created: string;
-  responses: ResponseOption[]
+  responses: ResponseOption[];
 };
 
 export type ResponseOption = {


### PR DESCRIPTION
Quick fix to set the `user_metadata.dataset` to the small arson dataset. Simply visit the '/sign-up' page to set the dataset id.

A couple of things were also picked up by the autoformatter along the way.