### PR TITLE
Fixed stale data closure issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,17 +20,16 @@
     "@supabase/supabase-js": "^1.35.6",
     "color-convert": "^2.0.1",
     "jotai": "^1.8.1",
-    "lodash": "^4.17.21",
     "next": "12.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-highlight-words": "^0.18.0",
     "react-hook-form": "^7.34.2",
-    "swr": "^1.3.0"
+    "swr": "^1.3.0",
+    "usehooks-ts": "^2.7.2"
   },
   "devDependencies": {
     "@types/color-convert": "^2.0.0",
-    "@types/lodash": "^4.14.185",
     "@types/node": "18.6.4",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",

--- a/src/components/semtex/CommentInput.tsx
+++ b/src/components/semtex/CommentInput.tsx
@@ -1,39 +1,34 @@
 import { TextField } from "@mui/material";
 import { useAtomValue } from "jotai";
-import { debounce } from "lodash";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import useUserResponse from "src/hooks/user_response";
+import { useDebounce } from "usehooks-ts";
 import { userResponseIdAtom } from "./Semtex";
 
 const CommentInput = () => {
   const userResponseID = useAtomValue(userResponseIdAtom);
   const { userResponse, updateComment } = useUserResponse(userResponseID);
-  const comment = userResponse?.comments;
 
-  const [textFieldVal, setTextFieldVal] = useState("");
+  const [comment, setComment] = useState("");
+
   useEffect(() => {
-    setTextFieldVal(comment ?? "");
-  }, [userResponseID]);
-
-  const debounceInput = useMemo(() => {
-    return debounce(
-      (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        updateComment(event.target.value);
-      },
-      500,
-      { leading: false, trailing: true }
-    );
+    setComment(userResponse?.comments ?? "");
   }, [userResponseID]);
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setTextFieldVal(event.target.value);
-    debounceInput(event);
+    setComment(event.target.value);
   };
+
+  const debouncedComment = useDebounce(comment, 500);
+
+  useEffect(() => {
+    updateComment(userResponse, debouncedComment);
+  }, [debouncedComment]);
 
   return (
     <TextField
       onChange={handleChange}
-      value={textFieldVal}
+      value={comment}
       multiline
       fullWidth
       placeholder="additional comments"

--- a/src/components/semtex/Highlighters.tsx
+++ b/src/components/semtex/Highlighters.tsx
@@ -75,7 +75,7 @@ const Highlighters = () => {
             </Button>
           ))}
           <Button
-            onClick={clearHighlights}
+            onClick={() => clearHighlights(userResponse)}
             variant="contained"
             fullWidth
             sx={{
@@ -94,7 +94,7 @@ const Highlighters = () => {
             }}
           >
             <Delete sx={{ marginRight: 2 }} />
-            Delete All
+            <span>Delete All</span>
           </Button>
         </Stack>
       </Box>

--- a/src/components/semtex/TextSample.tsx
+++ b/src/components/semtex/TextSample.tsx
@@ -104,7 +104,7 @@ const TextSample = () => {
       );
       (tempHighlights ?? []).push(newSelection as Highlight);
 
-      setHighlights(tempHighlights);
+      setHighlights(userResponse, tempHighlights);
     }
   };
 

--- a/src/components/semtex/response_selector/ResponseButtons.tsx
+++ b/src/components/semtex/response_selector/ResponseButtons.tsx
@@ -35,7 +35,7 @@ const ResponseButtons = () => {
           marginLeft: "5vw",
         }}
         onChange={(event) => {
-          updateResponseOption(event.target.value);
+          updateResponseOption(userResponse, event.target.value);
         }}
         row
       >

--- a/src/components/semtex/response_selector/ResponseDropdown.tsx
+++ b/src/components/semtex/response_selector/ResponseDropdown.tsx
@@ -25,7 +25,7 @@ const ResponseDropdown = () => {
         value={userResponse?.response?.id ?? ""}
         label="Response"
         onChange={(event) => {
-          updateResponseOption(event.target.value);
+          updateResponseOption(userResponse, event.target.value);
         }}
       >
         {responseOptions.map((responseOption) => {

--- a/src/hooks/user_response.tsx
+++ b/src/hooks/user_response.tsx
@@ -42,6 +42,7 @@ const useUserResponse = (userResponseID: string | undefined) => {
   };
 
   const setHighlights = async (
+    userResponse: UserResponse | undefined,
     highlights: Omit<Highlight, "id">[] | undefined
   ) => {
     if (highlights === undefined) return;
@@ -64,7 +65,7 @@ const useUserResponse = (userResponseID: string | undefined) => {
     );
 
     const newUserResponse = {
-      ...data,
+      ...userResponse,
       highlights: [...(highlights ?? [])].sort(
         (a, b) => a.startIndex - b.startIndex
       ),
@@ -77,14 +78,14 @@ const useUserResponse = (userResponseID: string | undefined) => {
     refetchUserReponseList();
   };
 
-  const clearHighlights = async () => {
+  const clearHighlights = async (userResponse: UserResponse | undefined) => {
     await supabase
       .from("highlight")
       .delete()
       .eq("user_response_id", userResponseID);
 
     const newUserResponse = {
-      ...data,
+      ...userResponse,
       highlights: [],
     };
 
@@ -95,16 +96,19 @@ const useUserResponse = (userResponseID: string | undefined) => {
     genericMutate(router.query.datasetID as string | undefined);
   };
 
-  const updateResponseOption = async (responseOptionID: string) => {
+  const updateResponseOption = async (
+    userResponse: UserResponse | undefined,
+    responseOptionID: string
+  ) => {
     await supabase
       .from("user_response")
       .update({
         response_option_id: responseOptionID,
       })
-      .eq("id", data.id)
+      .eq("id", data?.id)
       .single();
 
-    const newUserResponse = { ...data, responseOptionID };
+    const newUserResponse = { ...userResponse, responseOptionID };
 
     mutate(() => newUserResponse, {
       optimisticData: newUserResponse,
@@ -113,14 +117,19 @@ const useUserResponse = (userResponseID: string | undefined) => {
     refetchUserReponseList();
   };
 
-  const updateComment = async (newComment: string) => {
+  const updateComment = async (
+    userResponse: UserResponse | undefined,
+    newComment: string
+  ) => {
+    if (newComment === undefined) return;
+
     await supabase
       .from("user_response")
       .update({ comments: newComment })
-      .eq("id", data.id)
+      .eq("id", data?.id)
       .single();
 
-    const newUserResponse = { ...data, comments: newComment };
+    const newUserResponse = { ...userResponse, comments: newComment };
 
     mutate(() => newUserResponse, {
       optimisticData: newUserResponse,

--- a/yarn.lock
+++ b/yarn.lock
@@ -734,11 +734,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.185":
-  version "4.14.185"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.185.tgz#c9843f5a40703a8f5edfd53358a58ae729816908"
-  integrity sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==
-
 "@types/node@18.6.4":
   version "18.6.4"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz"
@@ -1995,11 +1990,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -2675,6 +2665,11 @@ use-sync-external-store@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
+usehooks-ts@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-2.7.2.tgz#5b1c166153f59fc63ae5408102be53608103c1d5"
+  integrity sha512-DeLqSnGg9VvpwPZA+6lKVURJKM9EBu7bbIXuYclQ9COO3w4lacnJa0uP0iJbC/lAmY7GlmPinjZfGNNmDTlUpg==
 
 utf-8-validate@^5.0.2:
   version "5.0.9"


### PR DESCRIPTION
There was a bug (which I unfortunately fixed before and then reintroduced) where the user response update functions were closures that contained stale data. The functions have been updated to take in a new copy of the user response to ensure that the data is always fresh. I also needed to modify the comment input component to ensure it was debounced correctly and only making network requests after a user stopped typing.